### PR TITLE
refactor: prefix router with v1 when initially

### DIFF
--- a/usage_service/web/api/v1/usage.py
+++ b/usage_service/web/api/v1/usage.py
@@ -1,8 +1,6 @@
 from fastapi import APIRouter
 
-router = APIRouter()
-
-router.prefix = "/v1"
+router = APIRouter(prefix="/v1")
 
 
 @router.get("/usage")


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Refactor the APIRouter initialization to include the prefix '/v1' directly in the constructor.